### PR TITLE
changed ipfind.co to ipfind.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ There are currently 8 different API's to choose from:
 - [freegeoip.net](https://freegeoip.net)
 - [ip-api.com](http://ip-api.com)
 - [ipapi.co](https://ipapi.co) (default)
-- [ipfind.co](https://ipfind.co)
+- [ipfind.com](https://ipfind.com)
 - [ipinfo.io](https://ipinfo.io)
 - [ipvigilante.com](https://ipvigilante.com)
 - [keycdn.com](https://tools.keycdn.com/geo)
@@ -225,7 +225,7 @@ To check if a cookie exists simply use `location.cached` which will return a boo
 }
 ```
 
-##### [ipfind.co](https://ipfind.co)
+##### [ipfind.com](https://ipfind.com)
 
 ```json
 {

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -35,7 +35,7 @@ class Settings extends Model
        ['value' => 'freegeoip', 'label' => 'freegeoip.net'],
        ['value' => 'ipapi', 'label' => 'ipapi.co'],
        ['value' => 'ipapicom', 'label' => 'ip-api.com'],
-       ['value' => 'ipfind', 'label' => 'ipfind.co'],
+       ['value' => 'ipfind', 'label' => 'ipfind.com'],
        ['value' => 'ipinfo', 'label' => 'ipinfo.io'],
        ['value' => 'ipvigilante', 'label' => 'ipvigilante.com'],
        ['value' => 'keycdn', 'label' => 'keycdn.com'],

--- a/src/services/GeoService.php
+++ b/src/services/GeoService.php
@@ -133,7 +133,7 @@ class GeoService extends Component
                  break;
 
              case 'ipfind':
-                 $clientUrl = 'https://ipfind.co';
+                 $clientUrl = 'https://api.ipfind.com';
                  $clientPath = '?ip='.$ipAddress.'&auth='.$settings->apiKey;
                  break;
 


### PR DESCRIPTION
Hi. ipfind.co moved to the new domain name and slightly changed their api link. So I added these changes.